### PR TITLE
Add a CI script for building release executables for all desktop OSes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: 'stable'
+
+      - if: runner.os == 'Linux'
+        run: sudo apt install -y libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libgl-dev libxxf86vm-dev mingw-w64
+
+      - run: nimble build -Y
+      - run: nimble deploy
+
+      - run: |
+          exe_name="animdustry_${{github.ref_name}}"
+          release_dir="${RUNNER_TEMP}/release"
+          mkdir -p "${release_dir}"
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+            cp "build/main-linux64" "${release_dir}/${exe_name}_linux64"
+            cp "build/main-win64.exe" "${release_dir}/${exe_name}_win64.exe"
+          elif [[ "${RUNNER_OS}" == "macOS" ]]; then
+            cp "build/main-mac64" "${release_dir}/${exe_name}_mac64"
+          fi
+
+      - uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          name: ${{github.ref_name}}
+          draft: true
+          files: ${{runner.temp}}/release/*


### PR DESCRIPTION
The build procedure is far from optimal since it first compiles everything in debug mode so that faupack is available, and then compiles everything all over again with optimizations for the release. It seems that the build instructions in the README are outdated because `nim install` fails because it can't find (built) faupack (on the CI `~/.nimble/bin` is in the PATH). Anyway, the script creates a (draft) release when a tag is pushed, but if a release already exists (you have a 15 minute window to create it) the files will be simply attached to it.