### PR TITLE
deploying for m1 macs

### DIFF
--- a/animdustry.nimble
+++ b/animdustry.nimble
@@ -22,7 +22,8 @@ const
   builds = [
     (name: "linux64", os: "linux", cpu: "amd64", args: ""),
     (name: "win64", os: "windows", cpu: "amd64", args: "--gcc.exe:x86_64-w64-mingw32-gcc --gcc.linkerexe:x86_64-w64-mingw32-g++"),
-    (name: "mac64", os: "macosx", cpu: "amd64", args: "")
+    (name: "mac64", os: "macosx", cpu: "amd64", args: ""),
+    (name: "macm1", os: "macosx", cpu: "arm64", args: "")
   ]
 
 task pack, "Pack textures":


### PR DESCRIPTION
so basically `nimble deploy macm1` now produces an m1 binary (at least on an m1 mac, no clue if it compiles on anything else), also `nimble deploy mac` still refers to mac64

this can be combined with the x64 version using the `lipo` utility to create something for both cpus (but apparently you dont have a mac so don't worry about that)

<br>
<br>
<br>

thats it